### PR TITLE
ボウリングのスコア計算プログラムの実装

### DIFF
--- a/03.bowling/.rubocop.yml
+++ b/03.bowling/.rubocop.yml
@@ -1,0 +1,3 @@
+inherit_gem:
+  rubocop-fjord:
+    - "config/rubocop.yml"

--- a/03.bowling/Gemfile
+++ b/03.bowling/Gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+# gem "rails"
+group :development do
+  gem 'rubocop-fjord', require: false
+end

--- a/03.bowling/Gemfile
+++ b/03.bowling/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 # gem "rails"
 group :development do

--- a/03.bowling/Gemfile.lock
+++ b/03.bowling/Gemfile.lock
@@ -1,0 +1,44 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    json (2.7.1)
+    language_server-protocol (3.17.0.3)
+    parallel (1.23.0)
+    parser (3.2.2.4)
+      ast (~> 2.4.1)
+      racc
+    racc (1.7.3)
+    rainbow (3.1.1)
+    regexp_parser (2.8.3)
+    rexml (3.2.6)
+    rubocop (1.58.0)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.2.2.4)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.30.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.30.0)
+      parser (>= 3.2.1.0)
+    rubocop-fjord (0.3.0)
+      rubocop (>= 1.0)
+      rubocop-performance
+    rubocop-performance (1.19.1)
+      rubocop (>= 1.7.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
+    ruby-progressbar (1.13.0)
+    unicode-display_width (2.5.0)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  rubocop-fjord
+
+BUNDLED WITH
+   2.4.22

--- a/03.bowling/bowling.rb
+++ b/03.bowling/bowling.rb
@@ -2,10 +2,10 @@
 
 # フレーム単位のリストを返す
 def create_frames
-  input = ARGV[0].split(",")
+  input = ARGV[0].split(',')
   frames = [] # フレーム単位のリスト
 
-  while input.length > 0 do
+  while input.length.positive?
     # 10回目は全ての得点を代入して終了
     if frames.length == 9
       frames << input.dup
@@ -14,11 +14,11 @@ def create_frames
 
     frame = []
     frame << input.shift
-    if frame[0] == "X"
-      frame << "0"
-    else
-      frame << input.shift
-    end
+    frame << if frame[0] == 'X'
+               '0'
+             else
+               input.shift
+             end
     frames << frame
   end
   frames
@@ -26,7 +26,7 @@ end
 
 # フレームごとのスコアの合計値を返す
 def sum_frame_score(frame)
-  frame.sum {|score| score == "X" ? 10 : score.to_i}
+  frame.sum { |score| score == 'X' ? 10 : score.to_i }
 end
 
 # 全てのフレームのスコアの合計値を返す
@@ -36,20 +36,16 @@ def calculate_total_score(frames)
     score += sum_frame_score(frame)
 
     # 10回目の場合は終了
-    if index == 9
-      break
-    end
+    break if index == 9
 
     # ストライクの場合
-    if frame[0] == "X"
+    if frame[0] == 'X'
       score += sum_frame_score(frames[index + 1][0, 2])
-      if frames[index + 1][0] == "X" && index + 1 != 9    # 次のフレームがストライクの場合は、さらに次のフレームの1投目のスコアを加算
-        score += sum_frame_score(frames[index + 2][0, 1])
-      end
+      score += sum_frame_score(frames[index + 2][0, 1]) if frames[index + 1][0] == 'X' && index + 1 != 9 # 次のフレームがストライクの場合は、さらに次のフレームの1投目のスコアを加算
 
     # スペアの場合
     elsif (frame[0].to_i + frame[1].to_i) == 10
-      score += sum_frame_score(frames[index+1][0, 1])
+      score += sum_frame_score(frames[index + 1][0, 1])
     end
   end
   score

--- a/03.bowling/bowling.rb
+++ b/03.bowling/bowling.rb
@@ -1,0 +1,59 @@
+#! /usr/bin/env ruby
+
+# フレーム単位のリストを返す
+def create_frames
+  input = ARGV[0].split(",")
+  frames = [] # フレーム単位のリスト
+
+  while input.length > 0 do
+    # 10回目は全ての得点を代入して終了
+    if frames.length == 9
+      frames << input.dup
+      break
+    end
+
+    frame = []
+    frame << input.shift
+    if frame[0] == "X"
+      frame << "0"
+    else
+      frame << input.shift
+    end
+    frames << frame
+  end
+  frames
+end
+
+# フレームごとのスコアの合計値を返す
+def sum_frame_score(frame)
+  frame.sum {|score| score == "X" ? 10 : score.to_i}
+end
+
+# 全てのフレームのスコアの合計値を返す
+def calculate_total_score(frames)
+  score = 0
+  frames.each_with_index do |frame, index|
+    score += sum_frame_score(frame)
+
+    # 10回目の場合は終了
+    if index == 9
+      break
+    end
+
+    # ストライクの場合
+    if frame[0] == "X"
+      score += sum_frame_score(frames[index + 1][0, 2])
+      if frames[index + 1][0] == "X" && index + 1 != 9    # 次のフレームがストライクの場合は、さらに次のフレームの1投目のスコアを加算
+        score += sum_frame_score(frames[index + 2][0, 1])
+      end
+
+    # スペアの場合
+    elsif (frame[0].to_i + frame[1].to_i) == 10
+      score += sum_frame_score(frames[index+1][0, 1])
+    end
+  end
+  score
+end
+
+frames = create_frames
+puts calculate_total_score(frames)

--- a/03.bowling/bowling.rb
+++ b/03.bowling/bowling.rb
@@ -1,4 +1,5 @@
 #! /usr/bin/env ruby
+# frozen_string_literal: true
 
 # フレーム単位のリストを返す
 def create_frames

--- a/03.bowling/bowling.rb
+++ b/03.bowling/bowling.rb
@@ -3,22 +3,22 @@
 
 # フレーム単位のリストを返す
 def create_frames
-  input = ARGV[0].split(',')
+  scores = ARGV[0].split(',')
   frames = [] # フレーム単位のリスト
 
-  while input.length.positive?
+  while scores.length.positive?
     # 10回目は全ての得点を代入して終了
     if frames.length == 9
-      frames << input.dup
+      frames << scores.dup
       break
     end
 
     frame = []
-    frame << input.shift
+    frame << scores.shift
     frame << if frame[0] == 'X'
                '0'
              else
-               input.shift
+               scores.shift
              end
     frames << frame
   end


### PR DESCRIPTION
- bowling.rbの実装

## bowling.rbの仕様
- `create_frames`
  - 入力されたスコアの羅列をフレーム単位のスコアのリストに整形する
- `calculate_total_score(frames)`
  - `create_frames`の戻り値を引数に持ち、スコアの計算を行う

- 処理の流れとしては、入力されたスコアをフレームの形にし、それから`calculate_total_score`でスコアを計算するというものです。
- スコアを計算するときに、フレーム別に見た方が計算しやすいため、最初にスコアを整形しています。